### PR TITLE
Retrieve hostname from cluster metadata

### DIFF
--- a/e2e/create_config.sh
+++ b/e2e/create_config.sh
@@ -68,7 +68,7 @@ static_resources:
         io.solo.function_router:
           functions:
             uppercase:
-              host: $FUNCTION_HOST
               path: $FUNCTION_PATH
-        io.solo.azure_functions: {}
+        io.solo.azure_functions:
+          host: $FUNCTION_HOST
 EOF

--- a/source/common/http/filter/azure/metadata_function_retriever.cc
+++ b/source/common/http/filter/azure/metadata_function_retriever.cc
@@ -13,16 +13,23 @@ using Config::SoloMetadata;
 absl::optional<Function> MetadataFunctionRetriever::getFunction(
     const MetadataAccessor &metadataccessor) const {
 
+  absl::optional<const ProtobufWkt::Struct *> maybe_upstream_spec =
+      metadataccessor.getClusterMetadata();
+  if (!maybe_upstream_spec.has_value()) {
+    return {};
+  }
+
   absl::optional<const ProtobufWkt::Struct *> maybe_function_spec =
       metadataccessor.getFunctionSpec();
   if (!maybe_function_spec.has_value()) {
     return {};
   }
 
-  const ProtobufWkt::Struct &function_spec = *maybe_function_spec.value();
-
+  const ProtobufWkt::Struct &upstream_spec = *maybe_upstream_spec.value();
   absl::optional<const std::string *> host = SoloMetadata::nonEmptyStringValue(
-      function_spec, Config::AzureFunctionsMetadataKeys::get().HOST);
+      upstream_spec, Config::AzureFunctionsMetadataKeys::get().HOST);
+
+  const ProtobufWkt::Struct &function_spec = *maybe_function_spec.value();
   absl::optional<const std::string *> path = SoloMetadata::nonEmptyStringValue(
       function_spec, Config::AzureFunctionsMetadataKeys::get().PATH);
 

--- a/test/integration/azure_functions_filter_integration_test.cc
+++ b/test/integration/azure_functions_filter_integration_test.cc
@@ -32,12 +32,11 @@ public:
 
       auto *metadata = azure_functions_cluster.mutable_metadata();
 
-      // create some value to mark this cluster as Azure Functions.
       Config::Metadata::mutableMetadataValue(
           *metadata,
           Config::AzureFunctionsMetadataFilters::get().AZURE_FUNCTIONS,
           Config::AzureFunctionsMetadataKeys::get().HOST)
-          .set_string_value("dummy value");
+          .set_string_value("yourapp.azurewebsites.net");
 
       // TODO(yuval-k): use consts (filename mess)
       std::string functionalfilter = "io.solo.function_router";
@@ -55,9 +54,6 @@ public:
       ProtobufWkt::Struct *functionsspecstruct =
           functionstructspecvalue.mutable_struct_value();
 
-      (*functionsspecstruct
-            ->mutable_fields())[Config::AzureFunctionsMetadataKeys::get().HOST]
-          .set_string_value("yourapp.azurewebsites.net");
       (*functionsspecstruct
             ->mutable_fields())[Config::AzureFunctionsMetadataKeys::get().PATH]
           .set_string_value("/api/function?code=ApiKey");


### PR DESCRIPTION
Make `MetadataFunctionRetriever` retrieve the hostname from the cluster
metadata rather than from the function metadata.
An Azure Functions upstream is associated with a single Azure Function
App, hence all functions of the upstream share the same hostname. This
modification is intended to make it easier for Gloo to populate the
metadata.