### PR TITLE
e2e: Use plain-text ASCII encoding in `uppercase.cs`

### DIFF
--- a/e2e/uppercase.cs
+++ b/e2e/uppercase.cs
@@ -18,5 +18,5 @@ public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceW
 
     return message == null
         ? req.CreateResponse(HttpStatusCode.BadRequest, "Please pass a message on the query string or in the request body")
-        : req.CreateResponse(HttpStatusCode.OK, message.ToUpper());
+        : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(message.ToUpper()) };
 }


### PR DESCRIPTION
Make `uppercase.cs` create a response body using the `text/plain`
content type and the ASCII charset, rather than the default UTF-8.
This is in order to make it consistent with the implementations of the
`uppercase` function deployed on other cloud providers.